### PR TITLE
updated readme and fixed requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Golub and Sussillo (2018), "FixedPointFinder: A TensorFlow toolbox for identifyi
     $ pip install -r requirements-torch.txt
     ```
 
+    and, depending on if you would like to use the CPU or GPU, follow the install instructions on the [official pytorch installer](https://pytorch.org/get-started/locally/)
+
     For TensorFlow, use:
 
     ```bash
@@ -47,8 +49,8 @@ Advanced Python users and those wishing to develop [contributions](https://githu
 2. Install [compatible versions](https://github.com/mattgolub/fixed-point-finder/blob/master/requirements-cpu.txt) of the following prerequisites.
 
 * **NumPy, SciPy, Matplotlib** ([install SciPy stack](https://www.scipy.org/install.html), contains all of them).
-* **Scikit-learn** ([install](http://scikit-learn.org/)).
 
+* **Scikit-learn** ([install](http://scikit-learn.org/)).
 
 * **TensorFlow** (recommended version: 2.8; requires at least version 1.14; versions beyond 2.8 are not currently supported) ([install](https://www.tensorflow.org/install/)).
 

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,4 +1,3 @@
 numpy==1.24.3
 scikit-learn==1.2.2
 matplotlib==3.7.1
-pytorch=1.12.1


### PR DESCRIPTION
pytorch isn't an installable package. Also, probably best to force users to decide if they want a CPU or GPU install.

[Relevant github issue:How to add PyTorch to requirements.txt ](https://github.com/pytorch/pytorch/issues/29745)